### PR TITLE
Add drag and move zoom mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Zooming is activated by scrolling (using the mouse wheel) and moving the mouse c
     <img src="images/both.gif" width="512"/>
 </p>
 
-### dragmov
+### dragmove
 Drag and move mode Single-click to zoom in, click and drag to move the zoomed image, and double-click to zoom out.
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ def image_zoom(image: Union[Image.Image, np.ndarray],
 ### Parameters
 
 - `image`: The image to be displayed. It can be either a PIL Image or a NumPy array.
-- `mode`: The mode of interaction for zooming. Valid options are "default" (zoom on mousemove), "mousemove" (zoom on mousemove), "scroll" (zoom on scroll), or "both" (zoom on both mousemove and scroll). Default is "default".
+- `mode`: The mode of interaction for zooming. Valid options are "default" (zoom on mousemove), "mousemove" (zoom on mousemove), "scroll" (zoom on scroll), "both" (zoom on both mousemove and scroll) or "dragmove" (Single-click to zoom in, click and drag to move the zoomed image). Default is "default".
 - `size`: The desired size of the displayed image. If an integer is provided, the image will be resized to have that size (width = height). If a tuple of integers (width, height) is provided, the image will be resized to fit within the specified dimensions while maintaining its aspect ratio. Default is 512.
 - `keep_aspect_ratio`: Whether to maintain the aspect ratio of the image during resizing. If True, the image will be resized while preserving its aspect ratio. If False, the image will be resized to exactly match the provided size without preserving aspect ratio. Default is True.
 - `keep_resolution`: Whether to keep the original resolution for zooming. If True, use the original resolution for zooming. If False, use the resized image for zooming. Default is False.  
@@ -70,6 +70,10 @@ Zooming is activated by scrolling (using the mouse wheel) and moving the mouse c
 <p align="center">
     <img src="images/both.gif" width="512"/>
 </p>
+
+### dragmov
+Drag and move mode Single-click to zoom in, click and drag to move the zoomed image, and double-click to zoom out.
+
 
 ## Examples
 

--- a/app.py
+++ b/app.py
@@ -54,6 +54,7 @@ def main():
         type=["png", "jpg", "jpeg", "tiff", "bmp"],
         key="file_uploader1",
     )
+    
     if st.session_state.uploaded is not None:
         img = load_image(st.session_state.uploaded)
         st.session_state.image_name = st.session_state.uploaded.name
@@ -63,16 +64,19 @@ def main():
         st.session_state.image_name = "no-image.jpg"
     st.sidebar.divider()
 
-    mode = st.sidebar.radio("Select mode:", ["mousemove", "scroll", "both"], index=0)
+    mode = st.sidebar.radio("Select mode:", ["mousemove", "scroll", "both", "dragmove"], index=0)
     zoom_factor = st.sidebar.slider(
         "Select zoom factor:", min_value=1, max_value=5, value=2, step=1
     )
-    if mode != "mousemove":
+    if mode not in ["mousemove", "dragmove"]:
         increase_factor = st.sidebar.slider(
             "Select increase factor:", min_value=0.0, max_value=1.0, value=0.2, step=0.1
         )
     else:
         increase_factor = 0.0
+
+    keep_res = st.sidebar.checkbox("Keep resolution")
+
     st.sidebar.divider()
 
     ####################################################################
@@ -85,6 +89,7 @@ def main():
         size=st.session_state.size_image,
         zoom_factor=zoom_factor,
         increment=increase_factor,
+        keep_resolution=keep_res,
     )
 
 


### PR DESCRIPTION
Add drag and move zoom mode: #6

 Drag and move mode Single-click to zoom in, click and drag to move the zoomed image, and double-click to zoom out.